### PR TITLE
Add .NET Core 1.1 support

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -59,7 +59,7 @@ Instantiate the template to build and deploy the sample application
 
 [source]
 ----
-oc new-app --template=aspnet-s2i -p GIT_URI=https://github.com/redhat-developer/s2i-dotnetcore-ex
+oc new-app --template=aspnet-s2i
 ----
 
 The template can also be instantiated using the OpenShift web console. Login to the console and navigate to the desired project. Click the *Add to Project* button. Search and select the `aspnet-s2i`.

--- a/README.adoc
+++ b/README.adoc
@@ -22,7 +22,7 @@ After logging into an OpenShift environment and creating or using an existing pr
 
 [source]
 ----
-oc new-app registry.access.redhat.com/dotnet/dotnetcore-10-rhel7~https://github.com/redhat-developer/s2i-dotnetcore-ex --name=aspnet-app --context-dir=app
+oc new-app registry.access.redhat.com/dotnet/dotnetcore-11-rhel7~https://github.com/redhat-developer/s2i-dotnetcore-ex#dotnetcore-1.1 --name=aspnet-app --context-dir=app
 ----
 
 Create a new route so that the application is accessible outside the OpenShift environment

--- a/app/.s2i/bin/run
+++ b/app/.s2i/bin/run
@@ -2,8 +2,10 @@
 
 set -e
 
+DOTNET_FRAMEWORK="netcoreapp1.1"
+
 echo "---> Running data migration..."
-dotnet ef database update
+dotnet ef -f ${DOTNET_FRAMEWORK} database update
 
 echo "---> Running application ..."
-exec dotnet run
+exec dotnet run -f ${DOTNET_FRAMEWORK}

--- a/app/.s2i/environment
+++ b/app/.s2i/environment
@@ -1,0 +1,1 @@
+DOTNET_NPM_TOOLS=bower gulp

--- a/app/project.json
+++ b/app/project.json
@@ -1,46 +1,6 @@
 {
   "userSecretsId": "aspnet-WebApplication-0799fe3e-6eaf-4c5f-b40e-7c6bfd5dfa9a",
 
-  "dependencies": {
-    "Microsoft.NETCore.App": {
-      "version": "1.0.0",
-      "type": "platform"
-    },
-    "Microsoft.AspNetCore.Authentication.Cookies": "1.0.0",
-    "Microsoft.AspNetCore.Diagnostics": "1.0.0",
-    "Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore": "1.0.0",
-    "Microsoft.AspNetCore.Identity.EntityFrameworkCore": "1.0.0",
-    "Microsoft.AspNetCore.Mvc": "1.0.0",
-    "Microsoft.AspNetCore.Razor.Tools": {
-      "version": "1.0.0-preview2-final",
-      "type": "build"
-    },
-    "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0",
-    "Microsoft.AspNetCore.Server.Kestrel": "1.0.0",
-    "Microsoft.AspNetCore.StaticFiles": "1.0.0",
-    "Microsoft.EntityFrameworkCore.Sqlite": "1.0.0",
-    "Microsoft.EntityFrameworkCore.Tools": {
-      "version": "1.0.0-preview2-final",
-      "type": "build"
-    },
-    "Microsoft.Extensions.Configuration.EnvironmentVariables": "1.0.0",
-    "Microsoft.Extensions.Configuration.CommandLine": "1.0.0",
-    "Microsoft.Extensions.Configuration.Json": "1.0.0",
-    "Microsoft.Extensions.Configuration.UserSecrets": "1.0.0",
-    "Microsoft.Extensions.Logging": "1.0.0",
-    "Microsoft.Extensions.Logging.Console": "1.0.0",
-    "Microsoft.Extensions.Logging.Debug": "1.0.0",
-    "Microsoft.VisualStudio.Web.BrowserLink.Loader": "14.0.0",
-    "Microsoft.VisualStudio.Web.CodeGeneration.Tools": {
-      "version": "1.0.0-preview2-final",
-      "type": "build"
-    },
-    "Microsoft.VisualStudio.Web.CodeGenerators.Mvc": {
-      "version": "1.0.0-preview2-final",
-      "type": "build"
-    }
-  },
-
   "tools": {
     "Microsoft.AspNetCore.Razor.Tools": {
       "version": "1.0.0-preview2-final",
@@ -50,12 +10,8 @@
       "version": "1.0.0-preview2-final",
       "imports": "portable-net45+win8+dnxcore50"
     },
-    "Microsoft.EntityFrameworkCore.Tools": {
-      "version": "1.0.0-preview2-final",
-      "imports": [
-        "portable-net45+win8+dnxcore50",
-        "portable-net45+win8"
-      ]
+    "Microsoft.EntityFrameworkCore.Tools.DotNet": {
+      "version": "1.1.0-preview4-final"
     },
     "Microsoft.Extensions.SecretManager.Tools": {
       "version": "1.0.0-preview2-final",
@@ -71,12 +27,101 @@
   },
 
   "frameworks": {
+    "netcoreapp1.1": {
+      "imports": [
+        "dotnet5.6",
+        "dnxcore50",
+        "portable-net45+win8"
+      ],
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "version": "1.1.0",
+          "type": "platform"
+        },
+        "Microsoft.AspNetCore.Authentication.Cookies": "1.0.0",
+        "Microsoft.AspNetCore.Diagnostics": "1.0.0",
+        "Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore": "1.0.0",
+        "Microsoft.AspNetCore.Identity.EntityFrameworkCore": "1.0.0",
+        "Microsoft.AspNetCore.Mvc": "1.0.1",
+        "Microsoft.AspNetCore.Razor.Tools": {
+          "version": "1.0.0-preview2-final",
+          "type": "build"
+        },
+        "Microsoft.AspNetCore.Routing": "1.0.1",
+        "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0",
+        "Microsoft.AspNetCore.Server.Kestrel": "1.0.1",
+        "Microsoft.AspNetCore.StaticFiles": "1.0.0",
+        "Microsoft.EntityFrameworkCore.Sqlite": "1.0.1",
+        "Microsoft.EntityFrameworkCore.Tools.DotNet": {
+          "version": "1.1.0-preview4-final",
+          "type": "build"
+        },
+        "Microsoft.EntityFrameworkCore.Design": {
+          "version": "1.1.0",
+          "type": "build"
+        },
+        "Microsoft.Extensions.Configuration.EnvironmentVariables": "1.0.0",
+        "Microsoft.Extensions.Configuration.Json": "1.0.0",
+        "Microsoft.Extensions.Configuration.UserSecrets": "1.0.0",
+        "Microsoft.Extensions.Logging": "1.1.0.0",
+        "Microsoft.Extensions.Logging.Console": "1.1.0.0",
+        "Microsoft.Extensions.Logging.Debug": "1.1.0.0",
+        "Microsoft.VisualStudio.Web.BrowserLink.Loader": "14.0.0",
+        "Microsoft.VisualStudio.Web.CodeGeneration.Tools": {
+          "version": "1.0.0-preview2-update1",
+          "type": "build"
+        },
+        "Microsoft.VisualStudio.Web.CodeGenerators.Mvc": {
+          "version": "1.0.0-preview2-update1",
+          "type": "build"
+        }
+      }
+    },
     "netcoreapp1.0": {
       "imports": [
         "dotnet5.6",
         "dnxcore50",
         "portable-net45+win8"
-      ]
+      ],
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "version": "1.0.0",
+          "type": "platform"
+        },
+        "Microsoft.AspNetCore.Authentication.Cookies": "1.0.0",
+        "Microsoft.AspNetCore.Diagnostics": "1.0.0",
+        "Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore": "1.0.0",
+        "Microsoft.AspNetCore.Identity.EntityFrameworkCore": "1.0.0",
+        "Microsoft.AspNetCore.Mvc": "1.0.0",
+        "Microsoft.AspNetCore.Razor.Tools": {
+          "version": "1.0.0-preview2-final",
+          "type": "build"
+        },
+        "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0",
+        "Microsoft.AspNetCore.Server.Kestrel": "1.0.0",
+        "Microsoft.AspNetCore.StaticFiles": "1.0.0",
+        "Microsoft.EntityFrameworkCore.Sqlite": "1.0.0",
+        "Microsoft.EntityFrameworkCore.Tools": {
+          "version": "1.0.0-preview2-final",
+          "type": "build"
+        },
+        "Microsoft.Extensions.Configuration.EnvironmentVariables": "1.0.0",
+        "Microsoft.Extensions.Configuration.CommandLine": "1.0.0",
+        "Microsoft.Extensions.Configuration.Json": "1.0.0",
+        "Microsoft.Extensions.Configuration.UserSecrets": "1.0.0",
+        "Microsoft.Extensions.Logging": "1.0.0",
+        "Microsoft.Extensions.Logging.Console": "1.0.0",
+        "Microsoft.Extensions.Logging.Debug": "1.0.0",
+        "Microsoft.VisualStudio.Web.BrowserLink.Loader": "14.0.0",
+        "Microsoft.VisualStudio.Web.CodeGeneration.Tools": {
+          "version": "1.0.0-preview2-final",
+          "type": "build"
+        },
+        "Microsoft.VisualStudio.Web.CodeGenerators.Mvc": {
+          "version": "1.0.0-preview2-final",
+          "type": "build"
+        }
+      }
     }
   },
 

--- a/templates/aspnet-s2i-template.json
+++ b/templates/aspnet-s2i-template.json
@@ -52,7 +52,6 @@
                     }
                 ],
                 "selector": {
-                    "app": "${APPLICATION_NAME}",
                     "deploymentconfig": "${APPLICATION_NAME}"
                 },
                 "type": "ClusterIP",
@@ -163,14 +162,12 @@
                 ],
                 "replicas": 1,
                 "selector": {
-                    "app": "${APPLICATION_NAME}",
                     "deploymentconfig": "${APPLICATION_NAME}"
                 },
                 "template": {
                     "metadata": {
                         "creationTimestamp": null,
                         "labels": {
-                            "app": "${APPLICATION_NAME}",
                             "deploymentconfig": "${APPLICATION_NAME}"
                         }
                     },

--- a/templates/aspnet-s2i-template.json
+++ b/templates/aspnet-s2i-template.json
@@ -255,7 +255,7 @@
             "name": "GIT_REF",
             "description": "Set this to a branch name, tag or other ref of your repository if you are not using the default branch.",
             "displayName": "Git Branch",
-            "value": "master"
+            "value": "dotnetcore-1.1"
         },
         {
             "name": "GIT_CONTEXT_DIR",
@@ -271,7 +271,7 @@
         {
             "name": "ASP_UPSTREAM_IMAGE",
             "description": "Base OpenShift ASP S2I Image",
-            "value": "registry.access.redhat.com/dotnet/dotnetcore-10-rhel7",
+            "value": "registry.access.redhat.com/dotnet/dotnetcore-11-rhel7",
             "displayName": "Upstream S2I Image"
         },
         {

--- a/templates/aspnet-s2i-template.json
+++ b/templates/aspnet-s2i-template.json
@@ -4,9 +4,9 @@
     "metadata": {
         "name": "aspnet-s2i",
         "annotations": {
-            "description": "Application template for asp .NET applications",
+            "description": "Application template for ASP .NET applications",
             "tags": "quickstart,dotnet,.net",
-            "iconClass": "fa fa-code"
+            "iconClass": "icon-dotnet"
         }
     },
     "objects": [
@@ -24,7 +24,7 @@
             "kind": "ImageStream",
             "apiVersion": "v1",
             "metadata": {
-                "name": "s2i-aspnet"
+                "name": "dotnet"
             },
             "spec": {
                 "dockerImageRepository": "${ASP_UPSTREAM_IMAGE}"
@@ -105,7 +105,7 @@
                     "sourceStrategy": {
                         "from": {
                             "kind": "ImageStreamTag",
-                            "name": "s2i-aspnet:${ASP_UPSTREAM_IMAGE_TAG}"
+                            "name": "dotnet:${ASP_UPSTREAM_IMAGE_TAG}"
                         }
                     }
                 },


### PR DESCRIPTION
There is a 1.1 (RHEL) image available in the registry but current master is not compatible with that image. It works with the 1.0 image. These changes make the sample work with currently released dotnet/dotnetcore-11-rhel7 image and also the yet unreleased version in https://github.com/redhat-developer/s2i-dotnetcore master (1.1 folder). I've tested both.

Unfortunately, I didn't see a way to make the `tools` sections in project.json framework specific and the entity framework for 1.1 requires .NET Core 1.1. Thus, I've opted for a new branch. That is, after the merge we have:

`master` => 1.0 image example
`dotnetcore-1.1` => 1.1 image example

@tmds, @omajid: Thoughts?