### PR TITLE
Fixes the template use case.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -59,7 +59,7 @@ Instantiate the template to build and deploy the sample application
 
 [source]
 ----
-oc new-app --template=aspnet-s2i -p GIT_URI=https://github.com/redhat-developer/s2i-dotnetcore-ex
+oc new-app --template=aspnet-s2i
 ----
 
 The template can also be instantiated using the OpenShift web console. Login to the console and navigate to the desired project. Click the *Add to Project* button. Search and select the `aspnet-s2i`.

--- a/templates/aspnet-s2i-template.json
+++ b/templates/aspnet-s2i-template.json
@@ -52,7 +52,6 @@
                     }
                 ],
                 "selector": {
-                    "app": "${APPLICATION_NAME}",
                     "deploymentconfig": "${APPLICATION_NAME}"
                 },
                 "type": "ClusterIP",
@@ -163,14 +162,12 @@
                 ],
                 "replicas": 1,
                 "selector": {
-                    "app": "${APPLICATION_NAME}",
                     "deploymentconfig": "${APPLICATION_NAME}"
                 },
                 "template": {
                     "metadata": {
                         "creationTimestamp": null,
                         "labels": {
-                            "app": "${APPLICATION_NAME}",
                             "deploymentconfig": "${APPLICATION_NAME}"
                         }
                     },

--- a/templates/aspnet-s2i-template.json
+++ b/templates/aspnet-s2i-template.json
@@ -277,7 +277,7 @@
         {
             "name": "ASP_UPSTREAM_IMAGE_TAG",
             "description": "Base OpenShift ASP S2I Image Tag",
-            "value": "1.0",
+            "value": "latest",
             "displayName": "Upstream S2I Image Tag"
         },
         {

--- a/templates/aspnet-s2i-template.json
+++ b/templates/aspnet-s2i-template.json
@@ -4,9 +4,9 @@
     "metadata": {
         "name": "aspnet-s2i",
         "annotations": {
-            "description": "Application template for asp .NET applications",
+            "description": "Application template for ASP .NET applications",
             "tags": "quickstart,dotnet,.net",
-            "iconClass": "fa fa-code"
+            "iconClass": "icon-dotnet"
         }
     },
     "objects": [
@@ -24,7 +24,7 @@
             "kind": "ImageStream",
             "apiVersion": "v1",
             "metadata": {
-                "name": "s2i-aspnet"
+                "name": "dotnet"
             },
             "spec": {
                 "dockerImageRepository": "${ASP_UPSTREAM_IMAGE}"
@@ -105,7 +105,7 @@
                     "sourceStrategy": {
                         "from": {
                             "kind": "ImageStreamTag",
-                            "name": "s2i-aspnet:${ASP_UPSTREAM_IMAGE_TAG}"
+                            "name": "dotnet:${ASP_UPSTREAM_IMAGE_TAG}"
                         }
                     }
                 },
@@ -277,7 +277,7 @@
         {
             "name": "ASP_UPSTREAM_IMAGE_TAG",
             "description": "Base OpenShift ASP S2I Image Tag",
-            "value": "latest",
+            "value": "1.0",
             "displayName": "Upstream S2I Image Tag"
         },
         {


### PR DESCRIPTION
    oc new-app --template=aspnet-s2i –p GIT_URI=https://github.com/openshift-s2i/s2i-aspnet-example

Referenced in https://developers.redhat.com/blog/2016/06/16/simplifying-asp-net-applications-on-openshift-with-the-asp-net-core-s2i-builder/ works again.

I've also done some cosmetic cleanup.