### PR TITLE
Increase timeout for live/ready probes.

### DIFF
--- a/templates/aspnet-s2i-template.json
+++ b/templates/aspnet-s2i-template.json
@@ -183,15 +183,15 @@
                                     }
                                 ],
                                 "readinessProbe": {
-                                  "timeoutSeconds": 3,
-                                  "initialDelaySeconds": 3,
+                                  "timeoutSeconds": 15,
+                                  "initialDelaySeconds": 30,
                                   "httpGet": {
                                     "path": "/",
                                     "port": 8080
                                   }
                                 },
                                 "livenessProbe": {
-                                  "timeoutSeconds": 3,
+                                  "timeoutSeconds": 15,
                                   "initialDelaySeconds": 30,
                                   "httpGet": {
                                     "path": "/",


### PR DESCRIPTION
A timeout of 3 seconds seems short enough for some setups. Since this is a liveness/readiness probe we don't really want false positives. Increasing the timeout seems appropriate.

Thoughts?