### PR TITLE
Set DOTNET_PUBLISH=true in .s2i/environment.

### DIFF
--- a/app/.s2i/environment
+++ b/app/.s2i/environment
@@ -1,1 +1,2 @@
 DOTNET_NPM_TOOLS=bower gulp
+DOTNET_PUBLISH=true


### PR DESCRIPTION
This allows users to pick up the environment if the app is
instantiated via `oc new-app` rather than by using the template.