### PR TITLE
Update README so as to reference new template.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,31 +1,44 @@
 [[s2i-aspnet-example]]
-= .NET Core Sample App on OpenShift
+= .NET Core Sample App for OpenShift
 
 This repository contains an example project that can be built using the
-https://github.com/openshift-s2i/s2i-aspnet[s2i-aspnet] builder image,
-which can be used to create reproducible Docker images from your ASP.NET
-project's source code.  The resulting images can be run using https://docker.com[Docker] or deployed to OpenShift.
+https://github.com/redhat-developer/s2i-dotnetcore[s2i-dotnetcore] builder
+image, which can be used to create reproducible Docker images from your .NET
+Core project's source code. The resulting images can be run using
+https://docker.com[Docker] or deployed to OpenShift.
 
 For more information about using these images with OpenShift, please see
 the official
-https://docs.openshift.com/enterprise/latest/using_images/s2i_images/index.html[OpenShift
+https://docs.openshift.com/enterprise/latest/using_images/s2i_images/dot_net_core.html[OpenShift
 Documentation].
-
 
 = Building and Running 
 
-The sample application can be built and run either within OpenShift or standalone by combining the application using s2i tool and running with existing image using Docker. The following sections describes these processes
+The sample application can be built and run either within OpenShift or
+standalone by combining the application using s2i tool and running with
+existing image using Docker. The following sections describes these processes.
 
 == OpenShift
 
-After logging into an OpenShift environment and creating or using an existing project, create a new application which combines the ASP.NET S2I builder and the sample application from this repository
+After logging into an OpenShift environment and creating or using an existing
+project, create a new application which combines the s2i-dotnetcore builder and
+the sample application from this repository:
+
+For .NET Core 1.0 use:
 
 [source]
 ----
-oc new-app registry.access.redhat.com/dotnet/dotnetcore-10-rhel7~https://github.com/redhat-developer/s2i-dotnetcore-ex --name=aspnet-app --context-dir=app
+oc new-app registry.access.redhat.com/dotnet/dotnetcore-10-rhel7~https://github.com/redhat-developer/s2i-dotnetcore-ex#dotnetcore-1.0 --name=aspnet-app --context-dir=app
 ----
 
-Create a new route so that the application is accessible outside the OpenShift environment
+For .NET Core 1.1 use:
+
+[source]
+----
+oc new-app registry.access.redhat.com/dotnet/dotnetcore-11-rhel7~https://github.com/redhat-developer/s2i-dotnetcore-ex#dotnetcore-1.1 --name=aspnet-app --context-dir=app
+----
+
+Next, create a new route so that the application is accessible outside the OpenShift environment
 
 [source]
 ----
@@ -36,13 +49,18 @@ The application will now be available at http://aspnet-app-&lt;project&gt;.&lt;d
 
 === Use a template to build and deploy a sample application
 
-A template has been provided to simplify the build and deployment of a  ASP.NET application on OpenShift. The template is located in the `templates` folder in a file called [aspnet-s2i-template.json](templates/aspnet-s2i-template.json).
+A template has been provided to simplify the build and deployment of a .NET
+Core application on OpenShift. The template is located in the `templates`
+folder of the https://github.com/redhat-developer/s2i-dotnetcore[s2i-dotnetcore
+repository]. File
+https://github.com/redhat-developer/s2i-dotnetcore/blob/master/templates/dotnet-example.json[dotnet-example.json]
 
-After logging into an OpenShift environment and creating or using an existing project, add the template to the project
+After logging into an OpenShift environment and creating or using an existing
+project, add the template to the project
 
 [source]
 ----
-oc create -f templates/aspnet-s2i-template.json
+oc create -f https://raw.githubusercontent.com/redhat-developer/s2i-dotnetcore/master/templates/dotnet-example.json
 ----
 
 [NOTE]
@@ -51,52 +69,68 @@ Alternately, the template can be added to the `openshift` project so that it wil
 
 [source]
 ----
-oc create -f templates/aspnet-s2i-template.json -n openshift
+oc create -n openshift -f https://raw.githubusercontent.com/redhat-developer/s2i-dotnetcore/master/templates/dotnet-example.json
 ----
 =====================================================================
 
-Instantiate the template to build and deploy the sample application
+You can create the .NET Core sample application using the template with:
 
 [source]
 ----
-oc new-app --template=aspnet-s2i
+oc process dotnet-example NAME=aspnet-app NAMESPACE=<project-name> DOTNET_IMAGE_STREAM_TAG=dotnet:1.1 SOURCE_REPOSITORY_REF=dotnetcore-1.1 | oc create -f -
 ----
 
-The template can also be instantiated using the OpenShift web console. Login to the console and navigate to the desired project. Click the *Add to Project* button. Search and select the `aspnet-s2i`.
+The template can also be instantiated using the OpenShift web console. Login to
+the console and navigate to the desired project. Click the *Add to Project*
+button. Search and select the one with name `dotnet-example`.
 
-Click *Create* to start a build and deploy the sample application.
+Click *Create* to start a build and deploy the sample application. You can
+choose to modify some some of the template parameters as you like. For example,
+the above `oc process` invocation changes relevant parameters so that the .NET
+Core 1.1 image gets selected and the corresponding `dotnetcore-1.1` branch will
+be being used for building the app. More information about supported
+environment variables can be found in the
+https://github.com/redhat-developer/s2i-dotnetcore[s2i-dotnetcore repository]
+in the corresponding image version's subfolder. For example for 1.0 see:
+https://github.com/redhat-developer/s2i-dotnetcore/blob/master/1.0/README.md#environment-variables
 
-Once the build has completed and the resulting container started, the application will be available at http://aspnet-app-&lt;project&gt;.&lt;default_subdomain&gt;
+Once the build has completed and the resulting container started, the
+application will be available at
+http://aspnet-app-&lt;project&gt;.&lt;default_subdomain&gt;
 
 
 # Standalone
 
-To build a new ASP.NET application using a previously existing S2I builder, execute the following command:
+To build a new .NET Core application using a previously existing s2i-dotnetcore
+builder, `dotnet/dotnetcore-10-rhel7`, execute the following command:
 
 [source]
 ----
-git clone https://github.com/redhat-developer/s2i-dotnetcore-ex.git
-cd s2i-dotnetcore-ex
-s2i build app/ aspapp aspnet-app --loglevel=5
+s2i build --ref=dotnetcore-1.0 --context-dir=app https://github.com/redhat-developer/s2i-dotnetcore-ex dotnet/dotnetcore-10-rhel7 aspnet-app
 ----
 
 The resulting image can be executed using docker:
 
 [source]
 ----
-docker run -t -p 5000:5000 aspnet-app
+docker run -d -p 8080:8080 aspnet-app
 ----
 
 Once the container is running, it should be accessible using:
 
 [source]
 ----
-curl 127.0.0.1:5000
+curl http://127.0.0.1:8080
 ----
 
 = Liveness and Readiness Application Health
 
-The template has been configured with a liveness and readiness probe of which you can read more at https://docs.openshift.com/enterprise/latest/dev_guide/application_health.html.  It checks if the container is healthy by doing a HTTP call to the root application.   It checks if the application is ready by performing an HTTP call to /Home/About.  If you'd like to see how the probe is working, just `oc log -f <pod>`.
+The template has been configured with a liveness and readiness probe of which
+you can read more at
+https://docs.openshift.com/enterprise/latest/dev_guide/application_health.html.
+It checks if the container is healthy by doing a HTTP call to the root
+application. It checks if the application is ready by the same mechanism. If
+you'd like to see how the probe is working, use: `oc log -f <pod>`.
 
 [[contributing]]
 Contributing
@@ -111,7 +145,7 @@ for details.
 Copyright and License
 ~~~~~~~~~~~~~~~~~~~~~
 
-Copyright 2016 by Red Hat, Inc.
+Copyright 2016-2017 by Red Hat, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not
 use this package except in compliance with the License (see the `LICENSE` file


### PR DESCRIPTION
It no longer references the deprecated template. I plan to remove the old template once the new one has been around for a while.

A rendered page of this is here:
https://github.com/jerboaa/s2i-dotnetcore-ex/tree/readme-update